### PR TITLE
Change flush timestamp to rethink time obj

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -36,8 +36,7 @@ internals.Connection.prototype.flush = function() {
 
         try {
 
-            var now = new Date().getTime();
-            this.table.filter(RethinkDB.row('expiresAt').lt(now)).delete().run(this.client);
+            this.table.filter(RethinkDB.row('expiresAt').lt(RethinkDB.now())).delete().run(this.client);
         }
 
         catch (err) {


### PR DESCRIPTION
Comparing on time appears to require a rethink time object, not timestamp. Passing a timestamp was causing that filter to return no results. It has been updated to rethink.now which returns a time object (http://rethinkdb.com/api/javascript/now/) set to the current time. Flush now works as expected.
