### PR TITLE
Remove single connection to use rethinkdbdash connection pool

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,16 +16,21 @@ internals.defaults = {
     max: 100
 };
 
+var isConnected = function() {
+    return RethinkDB.getPoolMaster().getNumConnections() > 0;
+};
 
 exports = module.exports = internals.Connection = function (options) {
 
     Hoek.assert(this.constructor === internals.Connection, 'RethinkDB cache client must be instantiated using new');
 
     this.settings = Hoek.applyToDefaults(internals.defaults, options);
+
     RethinkDB = require('rethinkdbdash')(this.settings);
     this.table = RethinkDB.db(this.settings.db).table(this.settings.table);
-    this.client = null;
-    this.isConnected = false;
+
+    this.isConnected = isConnected;
+    this.started = false;
 
     return this;
 };
@@ -36,10 +41,9 @@ internals.Connection.prototype.flush = function() {
     setInterval(function() {
 
         try {
+            if (this.client.isReady()) {
 
-            if (this.client.open) {
-
-                this.table.between(RethinkDB.minval, RethinkDB.now(), {index: 'expiresAt'}).delete().run(this.client);
+                this.table.between(RethinkDB.minval, RethinkDB.now(), {index: 'expiresAt'}).delete().run();
             }
         }
 
@@ -50,117 +54,74 @@ internals.Connection.prototype.flush = function() {
     }.bind(this), this.settings.flushInterval);
 };
 
-
-internals.Connection.prototype.createDb = function () {
-
-    var self = this;
-
-    return RethinkDB.dbList().run(this.client)
-    .then(function(dbs) {
-
-        if (!Hoek.contain(dbs, self.settings.db)) {
-
-            return RethinkDB.dbCreate(self.settings.db).run(self.client);
-        }
-    });
-};
-
-
 internals.Connection.prototype.createTable = function () {
 
     var self = this;
 
-    return RethinkDB.tableList().run(this.client)
-    .then(function(tables) {
+    return RethinkDB.tableList().run()
+      .then(function(tables) {
 
-        if (!Hoek.contain(tables, self.settings.table)) {
+          if (!Hoek.contain(tables, self.settings.table)) {
 
-            return RethinkDB.tableCreate(self.settings.table).run(self.client);
-        }
-    });
+              return RethinkDB.tableCreate(self.settings.table).run();
+          }
+      });
 };
-
 
 internals.Connection.prototype.createIndex = function () {
 
     var self = this;
 
-    return RethinkDB.table(this.settings.table).indexList().run(this.client)
-    .then(function(indexes) {
+    return RethinkDB.table(this.settings.table).indexList().run()
+      .then(function(indexes) {
 
-        if (!Hoek.contain(indexes, 'expiresAt')) {
+          if (!Hoek.contain(indexes, 'expiresAt')) {
 
-            return self.table.indexCreate('expiresAt').run(self.client);
-        }
-    });
+              return self.table.indexCreate('expiresAt').run();
+          }
+      });
 };
 
 
-internals.Connection.prototype.handleConnection = function(err, conn, callback) {
+internals.Connection.prototype.handleConnection = function(callback) {
 
     var self = this;
 
-    if (err) {
-        this.stop();
-        return callback(new Error(err));
-    }
-
-    this.isConnected = true;
-    this.client = conn;
-
-    // Ensure table is created
-    return this.createDb()
-    .then(function() {
-        return self.createTable();
-    })
-    .then(function() {
-        return self.createIndex();
-    })
-    .then(function() {
-        self.flush(conn);
-        return callback();
-    })
-    .error(function(err) {
-        return callback(new Error(err));
-    });
+    return self.createTable()
+      .then(function(){
+          self.createIndex();
+      })
+      .then(function() {
+          self.flush();
+          self.started = true;
+          return callback();
+      })
+      .error(function(err) {
+          return callback(new Error(err));
+      });
 
 };
 
 
 internals.Connection.prototype.start = function (callback) {
 
-    var self = this;
-
-    if (this.client) {
+    if (this.started) {
         return Hoek.nextTick(callback)();
     }
 
-    // Create client
-    return RethinkDB.connect({
-
-        host: this.settings.host,
-        port: this.settings.port,
-        db: this.settings.db
-    }, function(err, conn) {
-
-        return self.handleConnection(err, conn, callback);
-    });
+    return this.handleConnection(callback);
 };
 
 
 internals.Connection.prototype.stop = function () {
-
-    if (this.client) {
-        this.client.close();
-        this.client = null;
-        this.isConnected = false;
-    }
+    RethinkDB.getPoolMaster().drain();
+    this.started = false;
 };
 
 
 internals.Connection.prototype.isReady = function () {
 
-    return this.isConnected;
+    return (this.started && this.isConnected());
 };
 
 
@@ -181,7 +142,7 @@ internals.Connection.prototype.validateSegmentName = function (name) {
 internals.Connection.prototype.insert = function(record, callback) {
 
     try {
-        this.table.insert(record).run(this.client, function (err, result) {
+        this.table.insert(record).run(function (err, result) {
 
             if (err) {
                 return callback(err);
@@ -202,7 +163,7 @@ internals.Connection.prototype.replace = function(record, callback) {
 
     try {
 
-        this.table.get(record.id).replace(record).run(this.client, function (err, result) {
+        this.table.get(record.id).replace(record).run(function (err, result) {
 
             if (err) {
                 return callback(err);
@@ -221,15 +182,13 @@ internals.Connection.prototype.replace = function(record, callback) {
 
 internals.Connection.prototype.get = function (key, callback) {
 
-    var self = this;
-
-    if (!this.client) {
+    if (!this.isConnected()) {
         return callback(new Error('Connection not started'));
     }
 
     var cacheKey = this.generateKey(key);
 
-    this.table.get(cacheKey).run(this.client, function (err, result) {
+    this.table.get(cacheKey).run(function (err, result) {
 
         if (err) {
             return callback(err);
@@ -259,7 +218,7 @@ internals.Connection.prototype.set = function (key, value, ttl, callback) {
 
     var self = this;
 
-    if (!this.client) {
+    if (!this.isConnected()) {
         return callback(new Error('Connection not started'));
     }
 
@@ -297,13 +256,13 @@ internals.Connection.prototype.set = function (key, value, ttl, callback) {
 
 internals.Connection.prototype.drop = function (key, callback) {
 
-    if (!this.client) {
+    if (!this.isConnected()) {
         return callback(new Error('Connection not started'));
     }
 
     var cacheKey = this.generateKey(key);
 
-    this.table.get(cacheKey).delete().run(this.client, function (err, result) {
+    this.table.get(cacheKey).delete().run(function (err, result) {
 
         if (err) {
             return callback(err);

--- a/lib/index.js
+++ b/lib/index.js
@@ -41,10 +41,7 @@ internals.Connection.prototype.flush = function() {
     setInterval(function() {
 
         try {
-            if (this.client.isReady()) {
-
-                this.table.between(RethinkDB.minval, RethinkDB.now(), {index: 'expiresAt'}).delete().run();
-            }
+            this.table.between(RethinkDB.minval, RethinkDB.now(), {index: 'expiresAt'}).delete().run();
         }
 
         catch (err) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "catbox-rethinkdb",
   "description": "RethinkDB adapter for catbox",
-  "version": "1.0.7",
+  "version": "1.1.0",
   "author": "Brandon Martin <brandon@codedmart.com>",
   "main": "index.js",
   "homepage": "https://github.com/codedmart/catbox-rethinkdb",

--- a/test/index.js
+++ b/test/index.js
@@ -3,7 +3,6 @@
 var Code = require('code');
 var Lab = require('lab');
 var Catbox = require('catbox');
-var R = require('rethinkdb');
 var RethinkDB = require('..');
 
 
@@ -120,7 +119,6 @@ describe('RethinkDB', function () {
 
             var key = { id: 'x', segment: 'test' };
             client.set(key, '123', 500, function (err) {
-
                 expect(err).to.not.exist();
                 client.get(key, function (err, result) {
 
@@ -378,7 +376,7 @@ describe('RethinkDB', function () {
 
     describe('#start', function () {
 
-        it('sets client to when the connection succeeds', function (done) {
+        it('sets started to true', function (done) {
 
             var options = {
                 host: '127.0.0.1',
@@ -388,34 +386,12 @@ describe('RethinkDB', function () {
             var rethinkdb = new RethinkDB(options);
 
             rethinkdb.start(function (err) {
-
                 expect(err).to.not.exist();
-                expect(rethinkdb.client).to.exist();
+                expect(rethinkdb.started).to.equal(true);
                 done();
             });
         });
 
-        it('reuses the client when a connection is already started', function (done) {
-
-            var options = {
-                host: '127.0.0.1',
-                port: 28015
-            };
-
-            var rethinkdb = new RethinkDB(options);
-
-            rethinkdb.start(function (err) {
-
-                expect(err).to.not.exist();
-                var client = rethinkdb.client;
-
-                rethinkdb.start(function () {
-
-                    expect(client).to.equal(rethinkdb.client);
-                    done();
-                });
-            });
-        });
 
         it('returns an error when connection fails', function (done) {
 
@@ -430,7 +406,7 @@ describe('RethinkDB', function () {
 
                 expect(err).to.exist();
                 expect(err).to.be.instanceOf(Error);
-                expect(rethinkdb.client).to.not.exist();
+                expect(rethinkdb.started).to.equal(false);
                 done();
             });
         });
@@ -654,9 +630,11 @@ describe('RethinkDB', function () {
 
             rethinkdb.start(function () {
 
-                expect(rethinkdb.client).to.exist();
+                expect(rethinkdb.started).to.equal(true);
+                expect(rethinkdb.isConnected()).to.equal(true);
                 rethinkdb.stop();
-                expect(rethinkdb.client).to.not.exist();
+                expect(rethinkdb.started).to.equal(false);
+                expect(rethinkdb.isConnected()).to.equal(false);
                 done();
             });
         });


### PR DESCRIPTION
RethinkDbDash creates a connection pool when requiring the module by default.  This library does not disable the connection pool (so it is there), but also creates an individual connection which it forces all of the queries to use instead of pulling from the pool.  This change set removes that connection so the lib uses the existing connection pool.  
